### PR TITLE
Prevent users access to audios as static files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@
 
 # production
 /dist
-/assets
+/images
+/audios
 
 # mocks
 mock/

--- a/src/api/audios.ts
+++ b/src/api/audios.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import fs from 'fs';
 import path from 'path';
-import { ASSETS_DIR, FILE_KEYS, RPC_WS_URL } from '../utils/constants';
+import { Audios_DIR, FILE_KEYS, RPC_WS_URL } from '../utils/constants';
 import type { UploadParams } from '../utils/types';
 import WebSocket from 'ws';
 
@@ -19,7 +19,7 @@ router.get('/audio/:id/:key', async (req, res) => {
     return;
   }
 
-  const audioPath = path.join(__dirname, `..${ASSETS_DIR}/${id}${FILE_KEYS[key]}.mp3`);
+  const audioPath = path.join(__dirname, `..${Audios_DIR}/${id}${FILE_KEYS[key]}.mp3`);
 
   fs.stat(audioPath, (err, stats) => {
     if (err) {

--- a/src/api/audios.ts
+++ b/src/api/audios.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import fs from 'fs';
 import path from 'path';
-import { Audios_DIR, FILE_KEYS, RPC_WS_URL } from '../utils/constants';
+import { AUDIOS_DIR, FILE_KEYS, RPC_WS_URL } from '../utils/constants';
 import type { UploadParams } from '../utils/types';
 import WebSocket from 'ws';
 
@@ -19,7 +19,7 @@ router.get('/audio/:id/:key', async (req, res) => {
     return;
   }
 
-  const audioPath = path.join(__dirname, `..${Audios_DIR}/${id}${FILE_KEYS[key]}.mp3`);
+  const audioPath = path.join(__dirname, `..${AUDIOS_DIR}/${id}${FILE_KEYS[key]}.mp3`);
 
   fs.stat(audioPath, (err, stats) => {
     if (err) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,7 @@ import uploadRouter from './api/upload';
 import imagesRouter from './api/images';
 import audiosRouter from './api/audios';
 import statusRouter from './api/status';
-import { API_PREFIX, ASSETS_DIR } from './utils/constants';
+import { API_PREFIX, Images_DIR } from './utils/constants';
 
 const app = express();
 
@@ -16,7 +16,7 @@ origin: [/^https?:\/\/([a-z0-9]+[.])*muzikie[.]com$/]
 }));
 
 // Serving static files
-app.use('/', express.static(path.join(__dirname, `.${ASSETS_DIR}`)));
+app.use('/', express.static(path.join(__dirname, `.${Images_DIR}`)));
 
 // registering routes
 app.use(API_PREFIX, uploadRouter);

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,7 +6,7 @@ import uploadRouter from './api/upload';
 import imagesRouter from './api/images';
 import audiosRouter from './api/audios';
 import statusRouter from './api/status';
-import { API_PREFIX, Images_DIR } from './utils/constants';
+import { API_PREFIX, IMAGES_DIR } from './utils/constants';
 
 const app = express();
 
@@ -16,7 +16,7 @@ origin: [/^https?:\/\/([a-z0-9]+[.])*muzikie[.]com$/]
 }));
 
 // Serving static files
-app.use('/', express.static(path.join(__dirname, `.${Images_DIR}`)));
+app.use('/', express.static(path.join(__dirname, `.${IMAGES_DIR}`)));
 
 // registering routes
 app.use(API_PREFIX, uploadRouter);

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -1,13 +1,13 @@
 import multer from 'multer';
 import path from 'path';
-import { FILE_KEYS, ASSETS_DIR } from '../utils/constants';
+import { FILE_KEYS, Audios_DIR, Images_DIR } from '../utils/constants';
 import type { FileKeys } from '../utils/types';
 
 const regex = /^(\w{32})(\w{2})(.*)$/;
 
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {
-    cb(null, ASSETS_DIR);
+    file.mimetype == 'audio/mpeg' ? cb(null, Audios_DIR) : cb(null, Images_DIR)
   },
   filename: (req, file, cb) => {
     const match = file.originalname.match(regex);

--- a/src/models/file.ts
+++ b/src/models/file.ts
@@ -1,13 +1,19 @@
 import multer from 'multer';
 import path from 'path';
-import { FILE_KEYS, Audios_DIR, Images_DIR } from '../utils/constants';
+import { FILE_KEYS, AUDIOS_DIR, IMAGES_DIR } from '../utils/constants';
 import type { FileKeys } from '../utils/types';
 
 const regex = /^(\w{32})(\w{2})(.*)$/;
 
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {
-    file.mimetype == 'audio/mpeg' ? cb(null, Audios_DIR) : cb(null, Images_DIR)
+    const fileType = file.mimetype;
+
+    fileType.startsWith('audio/')
+      ? cb(null, AUDIOS_DIR)
+      : fileType.startsWith('image/')
+      ? cb(null, IMAGES_DIR)
+      : cb(new Error('Unsupported file type.'), '');
   },
   filename: (req, file, cb) => {
     const match = file.originalname.match(regex);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,6 +9,8 @@ export const FILE_KEYS: { [key in FileKeys]: string; } = {
 
 export const API_PREFIX = '/api';
 
-export const ASSETS_DIR = './assets';
+export const Images_DIR = './images';
+
+export const Audios_DIR = './audios';
 
 export const RPC_WS_URL = 'ws://127.0.0.1:7887/rpc-ws';

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,8 +9,8 @@ export const FILE_KEYS: { [key in FileKeys]: string; } = {
 
 export const API_PREFIX = '/api';
 
-export const Images_DIR = './images';
+export const IMAGES_DIR = './images';
 
-export const Audios_DIR = './audios';
+export const AUDIOS_DIR = './audios';
 
 export const RPC_WS_URL = 'ws://127.0.0.1:7887/rpc-ws';


### PR DESCRIPTION
### which issue does it resolve
Resovles #4 

### Description
 For obvious reasons users should have access to the audio assets strictly via the audios route. Such files should not be 
 accessible as static files.
 The API should prevent direct access to audio files, although images do not file under this category and users should be able to 
 retrieve them directly.